### PR TITLE
(#3) Move vscode.template source files to repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.nupkg
+_output/

--- a/src/vscode.template/CHANGELOG.md
+++ b/src/vscode.template/CHANGELOG.md
@@ -1,0 +1,10 @@
+# ![VSCode Package Template Changelog](https://img.shields.io/badge/VSCode%20Package%20Template%20Changelog-blue.svg?style=for-the-badge)
+
+## Version 1.0.1 (2021-10-14)
+
+- Moved template to common community repository for templates.
+- Fix template title using Install instead of VSCode Template.
+
+## Version 1.0 (2019-10-03)
+
+- Initial implementation of the VSCode Package Template using chocolatey-vscode.extension.

--- a/src/vscode.template/templates/tools/chocolateyInstall.ps1
+++ b/src/vscode.template/templates/tools/chocolateyInstall.ps1
@@ -1,0 +1,3 @@
+$ErrorActionPreference = 'Stop'
+
+Install-VsCodeExtension -extensionId '[[ExtensionId]]'

--- a/src/vscode.template/templates/tools/chocolateyUninstall.ps1
+++ b/src/vscode.template/templates/tools/chocolateyUninstall.ps1
@@ -1,0 +1,3 @@
+$ErrorActionPreference = 'Stop'
+
+Uninstall-VsCodeExtension -extensionId '[[ExtensionId]]'

--- a/src/vscode.template/templates/vscode.nuspec.template
+++ b/src/vscode.template/templates/vscode.nuspec.template
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Read this before creating packages: https://chocolatey.org/docs/create-packages -->
+<!-- Test your packages in a test environment: https://github.com/chocolatey/chocolatey-test-environment -->
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <!-- == PACKAGE SPECIFIC SECTION == -->
+    <!-- This section is about this package, although id and version have ties back to the software -->
+    <id>[[PackageNameLower]]</id>
+    <version>[[PackageVersion]]</version>
+    <packageSourceUrl>https://github.com/[[MaintainerRepo]]/[[PackageNameLower]]</packageSourceUrl>
+    <owners>[[MaintainerName]]</owners>
+    <!-- ============================== -->
+
+    <!-- == SOFTWARE SPECIFIC SECTION == -->
+    <!-- This section is about the software itself -->
+    <title>[[PackageName]] (VSCode Extension)</title>
+    <authors>__REPLACE_AUTHORS_OF_SOFTWARE_COMMA_SEPARATED__</authors>
+    <projectUrl>https://marketplace.visualstudio.com/items?itemName=[[ExtensionId]]</projectUrl>
+    <!-- <iconUrl>https://cdn.jsdelivr.net/gh/[[MaintainerRepo]]@master/icons/[[PackageNameLower]].png</iconUrl> -->
+    <!-- <copyright>Year Software Vendor</copyright> -->
+    <!-- If there is a license Url available, it is is required for the community feed -->
+    <licenseUrl>https://marketplace.visualstudio.com/items/[[ExtensionId]]/license</licenseUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <!--<projectSourceUrl>Software Source Location - is the software FOSS somewhere? Link to it with this</projectSourceUrl>-->
+    <!--<docsUrl>At what url are the software docs located?</docsUrl>-->
+    <!--<mailingListUrl></mailingListUrl>-->
+    <!--<bugTrackerUrl></bugTrackerUrl>-->
+    <tags>[[PackageNameLower]] extension vscode SPACE_SEPARATED</tags>
+    <summary>__REPLACE__</summary>
+    <description>__REPLACE__MarkDown_Okay [[AutomaticPackageNotesNuspec]]</description>
+    <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
+    <!-- =============================== -->
+
+    <!-- Specifying dependencies and version ranges? https://docs.nuget.org/create/versioning#specifying-version-ranges-in-.nuspec-files -->
+    <dependencies>
+      <dependency id="chocolatey-vscode.extension" version="1.0.0" />
+    </dependencies>
+
+    <!--<provides>NOT YET IMPLEMENTED</provides>-->
+    <!--<conflicts>NOT YET IMPLEMENTED</conflicts>-->
+    <!--<replaces>NOT YET IMPLEMENTED</replaces>-->
+  </metadata>
+  <files>
+    <!-- this section controls what actually gets packaged into the Chocolatey package -->
+    <file src="tools\**" target="tools" />
+    <!--Building from Linux? You may need this instead: <file src="tools/**" target="tools" />-->
+  </files>
+</package>

--- a/src/vscode.template/vscode.template.nuspec
+++ b/src/vscode.template/vscode.template.nuspec
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <!-- == PACKAGE SPECIFIC SECTION == -->
+    <!-- This section is about this package, although id and version have ties back to the software -->
+    <id>vscode.template</id>
+    <version>1.0.1</version>
+    <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-templates/tree/master/src/vscode.template</packageSourceUrl>
+    <owners>chocolatey-community,AdmiringWorm</owners>
+    <!-- ============================== -->
+
+    <!-- == SOFTWARE SPECIFIC SECTION == -->
+    <!-- This section is about the software itself -->
+    <title>VSCode Package Template</title>
+    <authors>Kim J. Nordmo</authors>
+    <projectUrl>https://github.com/chocolatey-community/chocolatey-templates/tree/master/src/vscode.template</projectUrl>
+    <!-- <iconUrl>https://cdn.rawgit.com/AdmiringWorm/chocolatey-packages/a52bba21db13c816b13a088638b42dae25404c5e/icons/vscode.template.png</iconUrl> -->
+    <copyright>Copyright © 2019-2021 - Kim J. Nordmo, Chocolatey Community</copyright>
+    <!-- If there is a license Url available, it is is required for the community feed -->
+    <licenseUrl>https://github.com/chocolatey-community/chocolatey-templates/blob/main/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <!--<projectSourceUrl>Software Source Location - is the software FOSS somewhere? Link to it with this</projectSourceUrl>-->
+    <!--<docsUrl>At what url are the software docs located?</docsUrl>-->
+    <!--<mailingListUrl></mailingListUrl>-->
+    <bugTrackerUrl>https://github.com/chocolatey-community/chocolatey-templates/issues</bugTrackerUrl>
+    <tags>templates vscode vscode-extension package</tags>
+    <summary>Starter template for creating packages for Visual Studio Code extensions.</summary>
+    <description>
+
+## Chocolatey VSCode extension template
+
+Starter template for creating packages for Visual Studio Code extensions.
+    </description>
+    <releaseNotes>https://github.com/chocolatey-community/chocolatey-templates/tree/master/src/vscode.template/CHANGELOG.md</releaseNotes>
+    <!-- =============================== -->
+
+    <!--<provides>NOT YET IMPLEMENTED</provides>-->
+    <!--<conflicts>NOT YET IMPLEMENTED</conflicts>-->
+    <!--<replaces>NOT YET IMPLEMENTED</replaces>-->
+  </metadata>
+  <files>
+    <!-- this section controls what actually gets packaged into the Chocolatey package -->
+    <file src="templates\**" target="templates" />
+    <!--Building from Linux? You may need this instead: <file src="tools/**" target="tools" />-->
+  </files>
+</package>

--- a/test/vscode.template.Tests.ps1
+++ b/test/vscode.template.Tests.ps1
@@ -1,0 +1,155 @@
+﻿Describe 'VSCode Template' {
+    BeforeAll {
+        $workDirectory = "$PSScriptRoot\..\_output\tests\vscode.template"
+        if (!(Test-Path $workDirectory)) {
+            # We use -Force here so it can create multiple directories
+            New-Item $workDirectory -ItemType Directory -Force
+        }
+        $workDirectory = Resolve-Path $workDirectory
+    }
+
+    AfterAll {
+        #Remove-Item $workDirectory -Recurse
+    }
+
+    Context 'New package without any additional arguments' {
+        BeforeDiscovery {
+            # We don't test for commented out values
+            $nuspecValues = @(
+                @{ Name = 'id'; Value = 'test-extension' }
+                @{ Name = 'version'; Value = '__REPLACE__' }
+                @{ Name = 'packageSourceUrl'; Value = 'https://github.com/__REPLACE_YOUR_REPO__/test-extension' }
+                @{ Name = 'owners'; Value = '__REPLACE_YOUR_NAME__' }
+                @{ Name = 'title'; Value = 'test-extension (VSCode Extension)' }
+                @{ Name = 'authors'; Value = '__REPLACE_AUTHORS_OF_SOFTWARE_COMMA_SEPARATED__' }
+                @{ Name = 'projectUrl'; Value = 'https://marketplace.visualstudio.com/items?itemName=[[ExtensionId]]' }
+                @{ Name = 'licenseUrl'; Value = 'https://marketplace.visualstudio.com/items/[[ExtensionId]]/license' }
+                @{ Name = 'requireLicenseAcceptance'; Value = 'true' }
+                @{ Name = 'tags'; Value = 'test-extension extension vscode SPACE_SEPARATED' }
+                @{ Name = 'summary'; Value = '__REPLACE__' }
+                @{ Name = 'description'; Value = '__REPLACE__MarkDown_Okay ' }
+            )
+        }
+
+        BeforeAll {
+            $identifier = 'test-extension'
+
+            choco new $identifier --outputdirectory "$workDirectory" --template 'vscode'
+        }
+
+        It 'Sets <Name> in nuspec to <Value>' -ForEach $nuspecValues {
+            "$workDirectory\$identifier\$identifier.nuspec" | Should -FileContentMatchExactly "<$Name>$([regex]::Escape($Value))</$Name>"
+        }
+
+        It 'Contains dependency on chocolatey-vscode.extension' {
+            "$workDirectory\$identifier\$identifier.nuspec" | Should -FileContentMatchExactly '<dependency id="chocolatey-vscode\.extension" version="1\.0\.0" />'
+        }
+
+        It 'Includes tools folder in files element' {
+            "$workDirectory\$identifier\$identifier.nuspec" | Should -FileContentMatchExactly '<file src="tools\\\*\*" target="tools" />'
+        }
+
+        It 'Creates installation script calling extension with extension id' {
+            "$workDirectory\$identifier\tools\chocolateyInstall.ps1" | Should -FileContentMatchMultilineExactly @"
+\`$ErrorActionPreference = 'Stop'
+
+Install-VsCodeExtension -extensionId '\[\[ExtensionId\]\]'
+"@
+        }
+
+        It 'Creates uninstallation script calling extension with extension id' {
+            "$workDirectory\$identifier\tools\chocolateyUninstall.ps1" | Should -FileContentMatchMultilineExactly @"
+\`$ErrorActionPreference = 'Stop'
+
+Uninstall-VsCodeExtension -extensionId '\[\[ExtensionId\]\]'
+"@
+        }
+    }
+
+    Context 'New package with custom extension identifier' {
+        BeforeDiscovery {
+            # We don't test for commented out values
+            $nuspecValues = @(
+                @{ Name = 'id'; Value = 'test-extension-id' }
+                @{ Name = 'title'; Value = 'test-extension-id (VSCode Extension)' }
+                @{ Name = 'projectUrl'; Value = 'https://marketplace.visualstudio.com/items?itemName=gep13.chocolatey-vscode' }
+                @{ Name = 'licenseUrl'; Value = 'https://marketplace.visualstudio.com/items/gep13.chocolatey-vscode/license' }
+                @{ Name = 'tags'; Value = 'test-extension-id extension vscode SPACE_SEPARATED' }
+            )
+        }
+
+        BeforeAll {
+            $identifier = 'test-extension-id'
+
+            choco new $identifier --outputdirectory "$workDirectory" --template 'vscode' extensionId="gep13.chocolatey-vscode"
+        }
+
+        It 'Sets <Name> in nuspec to <Value>' -ForEach $nuspecValues {
+            "$workDirectory\$identifier\$identifier.nuspec" | Should -FileContentMatchExactly "<$Name>$([regex]::Escape($Value))</$Name>"
+        }
+
+        It 'Creates installation script calling extension with extension id' {
+            "$workDirectory\$identifier\tools\chocolateyInstall.ps1" | Should -FileContentMatchMultilineExactly @"
+\`$ErrorActionPreference = 'Stop'
+
+Install-VsCodeExtension -extensionId 'gep13.chocolatey-vscode'
+"@
+        }
+
+        It 'Creates uninstallation script calling extension with extension id' {
+            "$workDirectory\$identifier\tools\chocolateyUninstall.ps1" | Should -FileContentMatchMultilineExactly @"
+\`$ErrorActionPreference = 'Stop'
+
+Uninstall-VsCodeExtension -extensionId 'gep13.chocolatey-vscode'
+"@
+        }
+
+        Context 'New package with uppercase identifier' {
+            BeforeDiscovery {
+                $nuspecValues = @(
+                    @{ Name = 'id'; Value = 'test-kebab-title-case' }
+                    @{ Name = 'title'; Value = 'Test-Kebab-Title-Case (VSCode Extension)' }
+                    @{ Name = 'packageSourceUrl'; Value = 'https://github.com/__REPLACE_YOUR_REPO__/test-kebab-title-case' }
+                    @{ Name = 'tags'; Value = 'test-kebab-title-case extension vscode SPACE_SEPARATED' }
+                )
+            }
+    
+            BeforeAll {
+                $identifier = 'Test-Kebab-Title-Case'
+    
+                choco new $identifier --outputdirectory "$workDirectory" --template 'vscode'
+            }
+    
+            It 'Sets <Name> in nuspec to <Value>' -ForEach $nuspecValues {
+                "$workDirectory\$identifier\$identifier.nuspec" | Should -FileContentMatchExactly "<$Name>$([regex]::Escape($Value))</$Name>"
+            }
+        }
+
+        # The following are additional replacement arguments typically
+        # specified by Chocolatey itself, or officially supported by
+        # Chocolatey.
+        Context 'New package using argument <Argument>' -ForEach @(
+            @{ Argument = '--version=5.0.0'; Name = 'version'; Value = '5.0.0' }
+            @{ Argument = '--maintainer=AdmiringWorm'; Name = 'owners'; Value = 'AdmiringWorm' }
+            @{ Argument = 'PackageVersion=3.2.2'; Name = 'version'; Value = '3.2.2' }
+            @{ Argument = 'MaintainerName="AdmiringWorm"'; Name = 'owners'; Value = 'AdmiringWorm' }
+            @{ Argument = 'MaintainerRepo="chocolatey-community/chocolatey-packages"'; Name = 'packageSourceUrl'; Value = 'https://github.com/chocolatey-community/chocolatey-packages/test-packagesourceurl' }
+        ) {
+            BeforeAll {
+                $identifier = "test-$Name"
+
+                choco new $identifier --template 'vscode' --outputdirectory "$workDirectory" $Argument
+            }
+
+            AfterAll {
+                # We remove the package directory here, so we don't get
+                # conflicts.
+                Remove-Item "$workDirectory\$identifier" -Recurse -Force
+            }
+
+            It 'Sets <Name> in nuspec to <Value>' {
+                "$workDirectory\$identifier\$identifier.nuspec" | Should -FileContentMatchExactly "<$Name>$([regex]::Escape($Value))</$Name>"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request moves the existing vscode.template file to this repository, together with Pester tests that can be used to verify new packages using this template are created as we expect.

Additionally a basic .gitignore file is added to make sure that any .nupkg files are ignore, and that the `_output` directory used by the tests is not committed.

fixes #3 