### PR TITLE
(doc) Update all URL's in files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/msi.template/templates/ReadMe.md
+++ b/src/msi.template/templates/ReadMe.md
@@ -1,4 +1,4 @@
-## Summary
+﻿## Summary
 How do I create packages? See https://docs.chocolatey.org/en-us/create/create-packages
 
 If you are submitting packages to the community feed (https://community.chocolatey.org)
@@ -10,36 +10,36 @@ Consider making this package an automatic package, for the best
 maintainability over time. Read up at https://docs.chocolatey.org/en-us/create/automatic-packages
 
 ## Shim Generation
-Any executables you include in the package or download (but don't call 
+Any executables you include in the package or download (but don't call
 install against using the built-in functions) will be automatically shimmed.
 
 This means those executables will automatically be included on the path.
-Shim generation runs whether the package is self-contained or uses automation 
-scripts. 
+Shim generation runs whether the package is self-contained or uses automation
+scripts.
 
 By default, these are considered console applications.
 
-If the application is a GUI, you should create an empty file next to the exe 
+If the application is a GUI, you should create an empty file next to the exe
 named 'name.exe.gui' e.g. 'bob.exe' would need a file named 'bob.exe.gui'.
 See https://docs.chocolatey.org/en-us/create/create-packages#how-do-i-set-up-shims-for-applications-that-have-a-gui
 
-If you want to ignore the executable, create an empty file next to the exe 
-named 'name.exe.ignore' e.g. 'bob.exe' would need a file named 
-'bob.exe.ignore'. 
+If you want to ignore the executable, create an empty file next to the exe
+named 'name.exe.ignore' e.g. 'bob.exe' would need a file named
+'bob.exe.ignore'.
 See https://docs.chocolatey.org/en-us/create/create-packages#how-do-i-exclude-executables-from-getting-shims
 
-## Self-Contained? 
-If you have a self-contained package, you can remove the automation scripts 
-entirely and just include the executables, they will automatically get shimmed, 
-which puts them on the path. Ensure you have the legal right to distribute 
+## Self-Contained?
+If you have a self-contained package, you can remove the automation scripts
+entirely and just include the executables, they will automatically get shimmed,
+which puts them on the path. Ensure you have the legal right to distribute
 the application though. See https://docs.chocolatey.org/en-us/information/legal.
 
-You should read up on the Shim Generation section to familiarize yourself 
+You should read up on the Shim Generation section to familiarize yourself
 on what to do with GUI applications and/or ignoring shims.
 
 ## Automation Scripts
 You have a powerful use of Chocolatey, as you are using PowerShell. So you
-can do just about anything you need. Choco has some very handy built-in 
+can do just about anything you need. Choco has some very handy built-in
 functions that you can use, these are sometimes called the helpers.
 
 ### Built-In Functions
@@ -71,14 +71,14 @@ The following are more advanced settings:
 
  * chocolateyPackageParameters = (0.9.8.22+)
  * CHOCOLATEY_VERSION = The version of Choco you normally see. Use if you are 'lighting' things up based on choco version. (0.9.9+)
-    - Otherwise take a dependency on the specific version you need. 
+    - Otherwise take a dependency on the specific version you need.
  * chocolateyForceX86 = If available and set to 'true', then user has requested 32bit version. (0.9.9+)
-    - Automatically handled in built in Choco functions. 
+    - Automatically handled in built in Choco functions.
  * OS_PLATFORM = Like Windows, OSX, Linux. (0.9.9+)
  * OS_VERSION = The version of OS, like 6.1 something something for Windows. (0.9.9+)
  * OS_NAME = The reported name of the OS. (0.9.9+)
  * IS_PROCESSELEVATED = Is the process elevated? (0.9.9+)
- 
+
 #### Experimental Environment Variables
 The following are experimental or use not recommended:
 
@@ -87,5 +87,5 @@ The following are experimental or use not recommended:
     - it's based on git describe
  * IS_ADMIN = Is the user an administrator? But doesn't tell you if the process is elevated. (0.9.9+)
  * chocolateyInstallOverride = Not for use in package automation scripts. (0.9.9+)
- * chocolateyInstallArguments = the installer arguments meant for the native installer. You should use chocolateyPackageParameters intead. (0.9.9+)
+ * chocolateyInstallArguments = the installer arguments meant for the native installer. You should use chocolateyPackageParameters instead. (0.9.9+)
 

--- a/src/msi.template/templates/ReadMe.md
+++ b/src/msi.template/templates/ReadMe.md
@@ -1,13 +1,13 @@
-﻿## Summary
-How do I create packages? See https://chocolatey.org/docs/create-packages
+## Summary
+How do I create packages? See https://docs.chocolatey.org/en-us/create/create-packages
 
-If you are submitting packages to the community feed (https://chocolatey.org)
+If you are submitting packages to the community feed (https://community.chocolatey.org)
 always try to ensure you have read, understood and adhere to the create
 packages wiki link above.
 
 ## Automatic Packaging Updates?
-Consider making this package an automatic package, for the best 
-maintainability over time. Read up at https://chocolatey.org/docs/automatic-packages
+Consider making this package an automatic package, for the best
+maintainability over time. Read up at https://docs.chocolatey.org/en-us/create/automatic-packages
 
 ## Shim Generation
 Any executables you include in the package or download (but don't call 
@@ -21,18 +21,18 @@ By default, these are considered console applications.
 
 If the application is a GUI, you should create an empty file next to the exe 
 named 'name.exe.gui' e.g. 'bob.exe' would need a file named 'bob.exe.gui'.
-See https://chocolatey.org/docs/create-packages#how-do-i-set-up-shims-for-applications-that-have-a-gui
+See https://docs.chocolatey.org/en-us/create/create-packages#how-do-i-set-up-shims-for-applications-that-have-a-gui
 
 If you want to ignore the executable, create an empty file next to the exe 
 named 'name.exe.ignore' e.g. 'bob.exe' would need a file named 
 'bob.exe.ignore'. 
-See https://chocolatey.org/docs/create-packages#how-do-i-exclude-executables-from-getting-shims
+See https://docs.chocolatey.org/en-us/create/create-packages#how-do-i-exclude-executables-from-getting-shims
 
 ## Self-Contained? 
 If you have a self-contained package, you can remove the automation scripts 
 entirely and just include the executables, they will automatically get shimmed, 
 which puts them on the path. Ensure you have the legal right to distribute 
-the application though. See https://chocolatey.org/docs/legal. 
+the application though. See https://docs.chocolatey.org/en-us/information/legal.
 
 You should read up on the Shim Generation section to familiarize yourself 
 on what to do with GUI applications and/or ignoring shims.
@@ -43,18 +43,18 @@ can do just about anything you need. Choco has some very handy built-in
 functions that you can use, these are sometimes called the helpers.
 
 ### Built-In Functions
-https://chocolatey.org/docs/helpers-reference
+https://docs.chocolatey.org/en-us/create/functions/
 
 A note about a couple:
-* Get-BinRoot - this is a horribly named function that doesn't do what new folks think it does. It gets you the 'tools' root, which by default is set to 'c:\tools', not the chocolateyInstall bin folder - see https://chocolatey.org/docs/helpers-get-tools-location
-* Install-BinFile - used for non-exe files - executables are automatically shimmed... - see https://chocolatey.org/docs/helpers-install-bin-file
-* Uninstall-BinFile - used for non-exe files - executables are automatically shimmed - see https://chocolatey.org/docs/helpers-uninstall-bin-file
+* Get-BinRoot - this is a horribly named function that doesn't do what new folks think it does. It gets you the 'tools' root, which by default is set to 'c:\tools', not the chocolateyInstall bin folder - see https://docs.chocolatey.org/en-us/create/functions/get-toolslocation
+* Install-BinFile - used for non-exe files - executables are automatically shimmed... - see https://docs.chocolatey.org/en-us/create/functions/install-binfile
+* Uninstall-BinFile - used for non-exe files - executables are automatically shimmed - see https://docs.chocolatey.org/en-us/create/functions/uninstall-binfile
 
 ### Getting package specific information
-Use the package parameters pattern - see https://chocolatey.org/docs/how-to-parse-package-parameters-argument
+Use the package parameters pattern - see https://docs.chocolatey.org/en-us/guides/create/parse-packageparameters-argument
 
 ### Need to mount an ISO?
-https://chocolatey.org/docs/how-to-mount-an-iso-in-chocolatey-package
+https://docs.chocolatey.org/en-us/guides/create/mount-an-iso-in-chocolatey-package
 
 
 ### Environment Variables

--- a/src/msi.template/templates/msi.nuspec.template
+++ b/src/msi.template/templates/msi.nuspec.template
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Read this before creating packages: https://docs.chocolatey.org/en-us/create/create-packages -->
 <!-- Test your packages in a test environment: https://github.com/chocolatey-community/chocolatey-test-environment -->
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
@@ -38,7 +38,7 @@
     <summary>__REPLACE__</summary>
     <description>__REPLACE__MarkDown_Okay [[AutomaticPackageNotesNuspec]]</description>
     <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
-    <!-- =============================== -->      
+    <!-- =============================== -->
 
     <!-- Specifying dependencies and version ranges? https://docs.microsoft.com/en-gb/nuget/concepts/package-versioning#version-ranges -->
     <!--<dependencies>

--- a/src/msi.template/templates/msi.nuspec.template
+++ b/src/msi.template/templates/msi.nuspec.template
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Read this before creating packages: https://chocolatey.org/docs/create-packages -->
-<!-- Test your packages in a test environment: https://github.com/chocolatey/chocolatey-test-environment -->
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Read this before creating packages: https://docs.chocolatey.org/en-us/create/create-packages -->
+<!-- Test your packages in a test environment: https://github.com/chocolatey-community/chocolatey-test-environment -->
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
@@ -10,11 +10,11 @@
     <!-- If the software is cross-platform, attempt to use the same id as the debian/rpm package(s) if possible. -->
     <id>[[PackageNameLower]]</id>
     <!-- version should MATCH as closely as possible with the underlying software -->
-    <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
+    <!-- Is the version a prerelease of a version? https://docs.microsoft.com/en-gb/nuget/concepts/package-versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
     <version>[[PackageVersion]]</version>
     <!--PackageSourceUrl - Where is this Chocolatey package located (think GitHub)? packageSourceUrl is highly recommended for the community feed-->
-    <packageSourceUrl>http://github.com/[[MaintainerRepo]]/[[PackageNameLower]]</packageSourceUrl>
+    <packageSourceUrl>https://github.com/[[MaintainerRepo]]/[[PackageNameLower]]</packageSourceUrl>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
     <owners>[[MaintainerName]]</owners>
     <!-- ============================== -->
@@ -25,7 +25,7 @@
     <authors>__REPLACE_AUTHORS_OF_SOFTWARE_COMMA_SEPARATED__</authors>
     <!-- projectUrl is required for the community feed -->
     <projectUrl>https://_Software_Location_REMOVE_OR_FILL_OUT_</projectUrl>
-    <!--<iconUrl>http://cdn.rawgit.com/[[MaintainerRepo]]/master/icons/[[PackageNameLower]].png</iconUrl>-->
+    <!-- <iconUrl>https://cdn.jsdelivr.net/gh/[[MaintainerRepo]]@master/icons/[[PackageNameLower]].png</iconUrl> -->
     <!-- <copyright>Year Software Vendor</copyright> -->
     <!-- If there is a license Url available, it is is required for the community feed -->
     <!-- <licenseUrl>Software License Location __REMOVE_OR_FILL_OUT__</licenseUrl>
@@ -40,7 +40,7 @@
     <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
     <!-- =============================== -->      
 
-    <!-- Specifying dependencies and version ranges? https://docs.nuget.org/create/versioning#specifying-version-ranges-in-.nuspec-files -->
+    <!-- Specifying dependencies and version ranges? https://docs.microsoft.com/en-gb/nuget/concepts/package-versioning#version-ranges -->
     <!--<dependencies>
       <dependency id="" version="__MINIMUM_VERSION__" />
       <dependency id="" version="[__EXACT_VERSION__]" />

--- a/src/msi.template/templates/tools/chocolateyinstall.ps1
+++ b/src/msi.template/templates/tools/chocolateyinstall.ps1
@@ -24,9 +24,9 @@ $packageArgs = @{
   validExitCodes= @(0, 3010, 1641)
 }
 
-#https://chocolatey.org/docs/helpers-install-chocolatey-package
+#https://docs.chocolatey.org/en-us/create/functions/install-chocolateypackage
 Install-ChocolateyPackage @packageArgs
 ## If you are making your own internal packages (organizations), you can embed the installer or
 ## put on internal file share and use the following instead (you'll need to add $file to the above)
-# https://chocolatey.org/docs/helpers-install-chocolatey-install-package
+# https://docs.chocolatey.org/en-us/create/functions/install-chocolateyinstallpackage
 #Install-ChocolateyInstallPackage @packageArgs

--- a/src/vscode.template/templates/vscode.nuspec.template
+++ b/src/vscode.template/templates/vscode.nuspec.template
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Read this before creating packages: https://chocolatey.org/docs/create-packages -->
-<!-- Test your packages in a test environment: https://github.com/chocolatey/chocolatey-test-environment -->
+<!-- Read this before creating packages: https://docs.chocolatey.org/en-us/create/create-packages -->
+<!-- Test your packages in a test environment: https://github.com/chocolatey-community/chocolatey-test-environment -->
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
@@ -32,7 +32,7 @@
     <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
     <!-- =============================== -->
 
-    <!-- Specifying dependencies and version ranges? https://docs.nuget.org/create/versioning#specifying-version-ranges-in-.nuspec-files -->
+    <!-- Specifying dependencies and version ranges? https://docs.microsoft.com/en-gb/nuget/concepts/package-versioning#version-ranges -->
     <dependencies>
       <dependency id="chocolatey-vscode.extension" version="1.0.0" />
     </dependencies>


### PR DESCRIPTION
A number of URL's within the templates were using older URL's that have
since been moved to different locations. While most of these have 301
redirects in place, it is better to use the actual URL's where possible.

Also updated to use https URL's rather than http ones.