### PR TITLE
Add PSADT template

### DIFF
--- a/src/psadt-silent.template/psadt-silent.template.nuspec
+++ b/src/psadt-silent.template/psadt-silent.template.nuspec
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>psadt-silent.template</id>
+    <version>1.0.0</version>
+    <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-templates/tree/main/src/psadt-silent.template</packageSourceUrl>
+    <owners>Stephen Valdinger, Chocolatey-Community</owners>
+    <title>PSADT Template</title>
+    <authors>Stephen Valdinger, The Chocolatey Team,Chocolatey Community Team</authors>
+    <projectUrl>https://github.com/chocolatey-community/chocolatey-templates</projectUrl>
+    <!--<iconUrl>http://rawcdn.githack.com/__REPLACE_YOUR_REPO__/master/icons/psadt-silent.template.png</iconUrl>-->
+    <copyright>Chocolatey Community Team 2023-present</copyright>
+    <licenseUrl>https://raw.githubusercontent.com/chocolatey-community/chocolatey-templates/main/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/chocolatey-community/chocolatey-templates</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/chocolatey-community/chocolatey-templates/issues</bugTrackerUrl>
+    <tags>psadt-silent.template SPACE_SEPARATED</tags>
+    <summary>PSADT Chocolatey Template</summary>
+    <description>### Chocolatey PSADT Template
+This adds a template for PSADT applications
+
+	</description>
+    <releaseNotes>
+### 1.0.0
+
+initial
+    </releaseNotes>
+  </metadata>
+  <files>
+    <!-- this section controls what actually gets packaged into the Chocolatey package -->
+    <file src="templates\**" target="templates" />
+  </files>
+</package>

--- a/src/psadt-silent.template/templates/file.nuspec.template
+++ b/src/psadt-silent.template/templates/file.nuspec.template
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>[[PackageNameLower]]</id>
+    <version>[[PackageVersion]]</version>
+    <title>[[Software]] (Install)</title>
+    <authors>UpdateAuthorHere</authors>
+    <!-- copyright is usually years and software vendor, but not required for internal feeds -->
+    <copyright>2023 CompanyName</copyright>
+    <tags>[[Software]] psadt</tags>
+    <summary>Installs [[Software]] via PSADT interactively</summary>
+    <description>
+    Uses existing PSADT framework to install [[Software]] via Chocolatey
+    </description>
+  </metadata>
+  <!-- this section controls what actually gets packaged into the Chocolatey package -->
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/src/psadt-silent.template/templates/tools/chocolateyinstall.ps1
+++ b/src/psadt-silent.template/templates/tools/chocolateyinstall.ps1
@@ -1,0 +1,67 @@
+﻿$ErrorActionPreference = 'Stop' # stop on all errors
+$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$zipArchive = Join-Path $toolsDir -ChildPath '[[Zip]]'
+$destination = (Join-Path $toolsDir -ChildPath $env:ChocolateyPackageName)
+
+Get-ChocolateyUnzip -FileFullPath $zipArchive -Destination $destination
+
+$adtFolder = 'AppDeployToolkit'
+$modulePath = Join-Path $destination -ChildPath "$adtFolder"
+$module = Join-Path $modulePath -ChildPath 'AppDeployToolkitMain.ps1'
+. $module
+$adtExe = Join-Path $destination -ChildPath "Deploy-Application.exe"
+$deployScript = Join-Path $destination -ChildPath 'Deploy-Application.ps1'
+
+try {
+    $packageArgs = @{
+        packagename = $env:ChocolateyPackageName
+        filetype = 'exe'
+        file = $adtExe
+        silentArgs = "-DeploymentType 'Install' -DeployMode 'Silent'"
+        validExitCodes = @(0)
+        softwareName = '[[Software]]*'
+    }
+
+    Install-ChocolateyInstallPackage @packageArgs
+} catch {
+    $packageArgs = @{
+        ExetoRun = $adtExe
+        statements = "-DeploymentType 'Install' -DeployMode 'Silent'"
+    }
+
+    Start-ChocolateyProcessAsAdmin @packageArgs
+} finally {
+    $packageArgs = @{
+        statements = "& { & '$deployScript' -DeploymentType 'Install'}"
+    }
+
+    Start-ChocolateyProcessAsAdmin @packageArgs
+}
+
+<#
+try {
+    $packageArgs = @{
+        ExetoRun = $adtExe
+        statements = "-DeploymentType 'Install' -DeployMode 'Silent'"
+    }
+
+    Start-ChocolateyProcessAsAdmin @packageArgs
+}
+
+catch {
+    $packageArgs = @{
+    
+        statements = "& { & '$deployScript' -DeploymentType 'Install'}"
+    }
+
+    Start-ChocolateyProcessAsAdmin @packageArgs
+}
+#>
+
+#Cleanup
+Remove-Item $zipArchive
+
+#Prevent shims
+if(-not (Test-Path "$destination\*.ignore")){
+    Get-ChildItem $toolsDir -Recurse -Filter '*.exe' | Foreach-Object { $null = New-Item "$destination\$($_.Name).ignore" -ItemType File }
+}

--- a/src/psadt-silent.template/templates/tools/chocolateyuninstall.ps1
+++ b/src/psadt-silent.template/templates/tools/chocolateyuninstall.ps1
@@ -1,0 +1,13 @@
+﻿$ErrorActionPreference = 'Stop' # stop on all errors
+$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$destination = (Join-Path $toolsDir -ChildPath $env:ChocolateyPackageName)
+
+
+$adtExe = Join-Path $destination -ChildPath "Deploy-Application.exe"
+
+$packageArgs = @{
+    ExetoRun = $adtExe
+    statements = "-DeploymentType 'Uninstall' -DeployMode 'Silent'"
+}
+
+Start-ChocolateyProcessAsAdmin @packageArgs


### PR DESCRIPTION
The [PSAppDeployToolkit](https://psappdeploytoolkit.com/) is a great framework for generating deployable executables with silent arguments. 

You can leverage these PSADT applications in Chocolatey packages if you zip them up and distribute them. This template helps a user create a Chocolatey package for PSADT applications.

Related: #5 